### PR TITLE
works with logrotate-2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG for opsline-chef-client
 
+# 0.20.0
+* Updated to work with logrotate-2.1.0
+
 ## 0.19.0
 * depend on `datadog` cookbook `>= 2.2.0`
 * fixing datadog chef status check error when status file does not exist

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'radek@opsline.com'
 license          'All rights reserved'
 description      'Helper recipes for chef client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.19.0'
+version          '0.20.0'
 
 depends 'cron'
 depends 'logrotate'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -129,7 +129,7 @@ logrotate_app 'chef-client' do
   options ['copytruncate', 'missingok', 'compress', 'notifempty', 'delaycompress']
   frequency 'daily'
   rotate node['opsline-chef-client']['logrotate']['days']
-  enable node['opsline-chef-client']['logrotate']['enabled'] ? :create : :delete
+  enable node['opsline-chef-client']['logrotate'].has_key?('enabled') ? node['opsline-chef-client']['logrotate']['enabled'] : false
 end
 
 


### PR DESCRIPTION
@opsline-radek 

The `enabled` property is boolean, and chef will raise an exception, if a symbol is passed.

With the release of logrotate-2.1.0, we found that properties are checked more stringently ... Leading to converge failures. We updated this recipe, in our hosted chef account, and can successfully converge again.

